### PR TITLE
Implementation of graph options modal, only design with placeholder data

### DIFF
--- a/src/components/GraphOptions/GraphOptions.tsx
+++ b/src/components/GraphOptions/GraphOptions.tsx
@@ -1,0 +1,96 @@
+import styles from "./graphOptions.module.scss";
+import React from "react";
+
+const GraphOptions = ({ selector }) => {
+  return (
+    <tds-modal selector={selector} size="xs">
+      <h5 className="tds-headline-05" slot="header">
+        Options
+      </h5>
+      <div slot="body" className={styles.body}>
+        <tds-text-field
+          placeholder="Title"
+          label="Title"
+          label-position="outside"
+          size="md"
+          value="Placeholder"
+        ></tds-text-field>
+        <tds-textarea
+          label="Description"
+          helper="Character left"
+          max-length="140"
+          label-position="outside"
+          placeholder="Placeholder"
+          value="Placeholder"
+        ></tds-textarea>
+        <div className={styles.body__divider}>
+          <tds-divider orientation="horizontal"></tds-divider>
+        </div>
+        <tds-dropdown
+          name="dropdown"
+          label="Access level"
+          label-position="outside"
+          placeholder="Placeholder"
+          size="md"
+          open-direction="auto"
+        >
+          <tds-dropdown-option value="private">Private</tds-dropdown-option>
+          <tds-dropdown-option disabled value="semi-public">
+            Semi-Public
+          </tds-dropdown-option>
+          <tds-dropdown-option value="public">Public</tds-dropdown-option>
+        </tds-dropdown>
+        <div className={styles.body__securityUrlContainer}>
+          <a
+            href="https://it.reflex.scania.com/00005/7600.html"
+            target="_blank"
+          >
+            Named graph security
+          </a>
+        </div>
+        <tds-text-field
+          placeholder="Creator"
+          label="Creator"
+          label-position="outside"
+          size="md"
+          value="Placeholder"
+        ></tds-text-field>
+        <tds-text-field
+          placeholder="Contributor"
+          label="Contributor"
+          label-position="outside"
+          size="md"
+          value="Placeholder"
+        ></tds-text-field>
+        <div className={styles.body__contributorsContainer}>
+          <tds-button
+            type="button"
+            size="sm"
+            variant="ghost"
+            text="add contributors"
+          >
+            <tds-icon slot="icon" name="plus"></tds-icon>
+          </tds-button>
+        </div>
+      </div>
+      <span slot="actions">
+        <div className={styles.action}>
+          <tds-button
+            type="button"
+            size="sm"
+            variant="primary"
+            text="Confirm"
+          ></tds-button>
+          <tds-button
+            type="button"
+            size="sm"
+            variant="secondary"
+            text="Cancel"
+          ></tds-button>
+        </div>
+      </span>
+    </tds-modal>
+  );
+};
+
+export default GraphOptions;

--- a/src/components/GraphOptions/graphOptions.module.scss
+++ b/src/components/GraphOptions/graphOptions.module.scss
@@ -1,0 +1,25 @@
+.body {
+  &__divider {
+    margin: 24px 0px;
+  }
+
+  &__securityUrlContainer {
+    margin: 10px 0px 16px 0px;
+    color: var(--Blue-400, #2b70d3);
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 16px;
+    letter-spacing: -0.14px;
+    text-decoration-line: underline;
+  }
+
+  &__contributorsContainer {
+    margin-top: 10px;
+    text-align: right;
+  }
+}
+
+.action {
+  display: flex;
+  gap: 16px;
+}

--- a/src/pages/ofd/Ofd.tsx
+++ b/src/pages/ofd/Ofd.tsx
@@ -34,6 +34,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import SelectionMenu from "../../components/ActionsMenu/EdgeSelectionMenu";
 import CircularNode from "../../components/CircularNode.tsx";
+import GraphOptions from "../../components/GraphOptions/GraphOptions";
 import DynamicForm from "./DynamicForm";
 import Sidebar from "./Sidebar";
 import styles from "./ofd.module.scss";
@@ -490,7 +491,10 @@ const ForceGraphComponent: React.FC = ({ apiBaseUrl }: any) => {
           </Link>
         </div>
         <div>
-          <span className={styles.page__header__options}>Options</span>
+          <span id="graph-options" className={styles.page__header__options}>
+            Options
+          </span>
+          <GraphOptions selector="#graph-options"/>
           <span className={styles.page__header__save} onClick={handleSaveClick}>
             Save
           </span>

--- a/src/pages/ofd/ofd.module.scss
+++ b/src/pages/ofd/ofd.module.scss
@@ -11,6 +11,7 @@
 
     &__options {
       margin-right: 20px;
+      cursor: pointer;
     }
 
     &__save {


### PR DESCRIPTION
![chrome-capture (14)](https://github.com/scania/sdos-orchestration-flow-designer/assets/113191538/cb3ba37e-ee43-42d2-a88e-b6aeaa431c01)

There is unwanted padding on the right and to the bottom of the "body"-slot of the modal from a constructed stylesheet. Will create a jira-ticket for it, since it affects all modals and is not really a part of this specific ticket.