### PR TITLE
Improve edge-design and add end marker

### DIFF
--- a/src/components/CustomEdge/CustomEdge.js
+++ b/src/components/CustomEdge/CustomEdge.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { getBezierPath, EdgeLabelRenderer, BaseEdge } from 'reactflow';
+import EndMarker from "./EndMarker"
+ 
+const CustomEdge = ({ id, data, ...props }) => {
+  const [edgePath, labelX, labelY] = getBezierPath(props);
+ 
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd="url('#end-marker')"/>
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            background: '#fff',
+            padding: 10,
+            borderRadius: 5,
+            fontSize: 12,
+            fontWeight: 700,
+          }}
+          className="nodrag nopan"
+        >
+          {props.label}
+        </div>
+        <EndMarker />
+      </EdgeLabelRenderer>
+    </>
+  );
+};
+ 
+export default CustomEdge;

--- a/src/components/CustomEdge/EndMarker.js
+++ b/src/components/CustomEdge/EndMarker.js
@@ -1,0 +1,35 @@
+import React from 'react';
+ 
+const EndMarker = ({selected}) => {
+ 
+  return (
+        <svg style={{ position: "absolute", top: 0, left: 0 }}>
+        <defs>
+          <marker
+            className="react-flow__arrowhead"
+            id="end-marker"
+            markerWidth="40"
+            markerHeight="40"
+            viewBox="-10 -10 20 20"
+            markerUnits="strokeWidth"
+            orient="auto-start-reverse"
+            refX="1"
+            refY="0"
+          >
+            <polyline
+              style={{
+                stroke: "#0d0f13",
+                fill: "#0d0f13",
+                strokeWidth: 1,
+              }}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              points="-5,-4 0,0 -5,4 -5,-4"
+            />
+          </marker>
+        </defs>
+      </svg>
+  );
+};
+ 
+export default EndMarker;

--- a/src/pages/ofd/Ofd.tsx
+++ b/src/pages/ofd/Ofd.tsx
@@ -32,6 +32,7 @@ import ReactFlow, {
   useNodesState,
 } from "reactflow";
 import "reactflow/dist/style.css";
+import CustomEdge from '../../components/CustomEdge/CustomEdge';
 import SelectionMenu from "../../components/ActionsMenu/EdgeSelectionMenu";
 import CircularNode from "../../components/CircularNode.tsx";
 import GraphOptions from "../../components/GraphOptions/GraphOptions";
@@ -217,6 +218,10 @@ const ForceGraphComponent: React.FC = ({
     setSelectedNode(null);
     setSetupMode(false);
   }, [setSelectedNode, setSetupMode]);
+
+  const edgeTypes = {
+    'custom-edge': CustomEdge,
+  };
 
   const onConnect = useCallback(
     (params: Edge<any> | Connection) => {
@@ -505,6 +510,7 @@ const ForceGraphComponent: React.FC = ({
                   fitViewOptions={{ maxZoom: 1 }}
                   onNodeClick={handleNodeClick}
                   nodeTypes={nodeTypes}
+                  edgeTypes={edgeTypes}
                 >
                   <Controls style={{ display: "flex" }} position="top-center" />
                   {/* @ts-ignore */}

--- a/src/styles/reactFlowOverrides.css
+++ b/src/styles/reactFlowOverrides.css
@@ -19,6 +19,14 @@
   background: #555 !important;
 }
 
+.react-flow__edge.selected .react-flow__edge-path {
+  stroke: #2058A8 !important; 
+}
+
+.react-flow__edge-path{
+  stroke: #37414F !important;
+}
+
 .react-flow__handle-connecting {
   background: red !important;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -118,7 +118,7 @@ export const setEdgeProperties = (
   //get source label
   const commonEdgeProps = {
     ...defaultParams,
-    markerEnd: { type: MarkerType.Arrow, width: 32, height: 32 },
+    type: 'custom-edge'
   };
   const pathName = path;
   const pathNameLabel = pathName?.split("/").pop() || "";


### PR DESCRIPTION
- Create an seperate file with the custom edge
- Create an seperate file with the custom end marker
- Label-text/container design now matches the figma design
- Added fill-color for selected edges
- Removed "markerEnd"-prop that only worked when loading a flow, and not when creating new edges

This MR does NOT include:
- Having the end-marker color match the selected/unselected state