### PR TITLE
Trim whitespaces from graph name

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -180,8 +180,17 @@ function App({
     name: string;
     description: string;
   }) => {
-    const { name, description } = data;
+    let { name, description } = data;
     clearErrors("name");
+    // removes whitespace from both sides of the name, but leaves whitespaces in the middle
+    name = data.name.trim()
+    if (name.length === 0) {
+      setError("name", {
+        type: "manual",
+        message: "Graph name can not be empty",
+      });
+      return;
+    }
     const nameExists = await checkNameExists(name.replace(/\s+/g, "-"));
     if (nameExists) {
       setError("name", {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -180,18 +180,18 @@ function App({
     name: string;
     description: string;
   }) => {
-    let { name, description } = data;
+    const { name, description } = data;
     clearErrors("name");
-    // removes whitespace from both sides of the name, but leaves whitespaces in the middle
-    name = data.name.trim()
-    if (name.length === 0) {
+    // Internal whitespaces are replaced with -, while leading and trailing spaces are removed entirely
+    const trimmedGraphName = name.trim().replace(/\s+/g, "-")
+    if (trimmedGraphName.length === 0) {
       setError("name", {
         type: "manual",
-        message: "Graph name can not be empty",
+        message: "Graph name is required",
       });
       return;
     }
-    const nameExists = await checkNameExists(name.replace(/\s+/g, "-"));
+    const nameExists = await checkNameExists(trimmedGraphName);
     if (nameExists) {
       setError("name", {
         type: "manual",
@@ -203,7 +203,7 @@ function App({
       {
         pathname: `/ofd/new`,
         query: {
-          graphName: name.replace(/\s+/g, "-"),
+          graphName: trimmedGraphName,
           description,
         },
       },


### PR DESCRIPTION
Trim whitespaces from the graph name removes possibilites of creating graph with a name of a single space. Even though we have a "required" check, it does not handle whitespaces since we want to change whitespaces to "-" in the middle of the graphname.