### PR TITLE
added close button to 'select parameter' popover

### DIFF
--- a/src/components/ActionsMenu/EdgeSelectionMenu.tsx
+++ b/src/components/ActionsMenu/EdgeSelectionMenu.tsx
@@ -1,6 +1,6 @@
 import styles from "./actionsMenu.module.scss";
 
-const EdgeSelectionMenu = ({ edges, onEdgeSelect }: any) => {
+const EdgeSelectionMenu = ({ edges, onEdgeSelect, onClose }: any) => {
   return (
     <div className={styles.container}>
       <ul className={styles.container__list}>
@@ -17,6 +17,9 @@ const EdgeSelectionMenu = ({ edges, onEdgeSelect }: any) => {
           );
         })}
       </ul>
+      <div onClick={() => onClose()} className={styles.container__close}>
+        <tds-icon name={"cross"}/>
+      </div>
     </div>
   );
 };

--- a/src/components/ActionsMenu/actionsMenu.module.scss
+++ b/src/components/ActionsMenu/actionsMenu.module.scss
@@ -2,6 +2,17 @@
   background: var(--tds-white);
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.15), 0 -1px 1px rgba(0, 0, 0, 0.1);
 
+  &__close{
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    background: white;
+    border: 1px solid #cdd1db;
+    padding: 2px;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+
   &__list {
     list-style: none;
     padding: 0px;

--- a/src/pages/ofd/Ofd.tsx
+++ b/src/pages/ofd/Ofd.tsx
@@ -87,6 +87,7 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
   const router = useRouter();
   const deletePressed = useKeyPress(["Delete"]);
   const [dropInfo, setDropInfo] = useState(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [droppedClassName, setDroppedClassName] = useState<null | string>(null);
   const [setupMode, setSetupMode] = useState(false);
   const [edgeSelections, setEdgeSelections] = useState<string[]>([]);
@@ -132,6 +133,7 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
     setConnectionParams(null);
     setEdgeSelections([]);
     setTargetNodePosition({ x: 0, y: 0 });
+    setIsPopoverOpen(false)
   };
 
   const isNodeDeletable = () => {
@@ -288,6 +290,7 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
       }
       setConnectionParams(params);
       setEdgeSelections([...paths]);
+      setIsPopoverOpen(true);
       captureCursorPosition(setTargetNodePosition);
       return;
     },
@@ -481,6 +484,16 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
     setSelectedNode(node);
   };
 
+  const handlePaneClick = () => {
+    // If popover is open, close it when clicking outside popover
+    setIsPopoverOpen(false);
+
+    // De-select node when clicking outside a node, except when in setup-mode
+    if(!setupMode) {
+      setSelectedNode(null)
+    }
+  }
+
   const handleExecute = () => {
     if (isDraft) {
       showToast(
@@ -575,11 +588,12 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
         <section className={styles.graph__canvas}>
           <div>
             <Popover
-              isOpen={!!edgeSelections.length}
+              isOpen={isPopoverOpen}
               content={
                 <SelectionMenu
                   edges={edgeSelections}
                   onEdgeSelect={onEdgeSelect}
+                  onClose={() => setIsPopoverOpen(false)}
                 ></SelectionMenu>
               }
               containerStyle={{
@@ -601,6 +615,7 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
                 }}
               >
                 <ReactFlow
+                  onPaneClick={handlePaneClick}
                   nodes={nodes}
                   edges={edges}
                   deleteKeyCode={isNodeDeletable() ? "Delete" : null}


### PR DESCRIPTION
Added both pane-click to hide the popover, but also a button to manually close it. This is due to the following scenarios:

* Clicking outside reactflow-container doesnt trigger "onPaneClick"
* Beeing in setup-mode, and focusing a input. does not trigger onPaneClick, and therefore does not close the popover.

There are a couple more unusual cases where the popover doesnt close, so I think the btn to manually close it is justified, although not super pretty atm :)