### PR TITLE
Task node no longer deletable

### DIFF
--- a/src/components/CircularNode.tsx/index.tsx
+++ b/src/components/CircularNode.tsx/index.tsx
@@ -1,6 +1,6 @@
-import { memo, useState } from "react";
+import { memo, useState, useEffect } from "react";
 import { Popover } from "react-tiny-popover";
-import { Handle, Position, useReactFlow } from "reactflow";
+import { Handle, Position, useReactFlow, useKeyPress } from "reactflow";
 import styles from "./CircularNode.module.scss";
 import ActionsMenu from "../ActionsMenu/ActionsMenu";
 import useOfdStore from '@/store/ofdStore';
@@ -23,6 +23,8 @@ const isParameter = (label) => {
 
 export default memo((node) => {
   //@ts-ignore
+  const deletePressed = useKeyPress(["Delete"]);
+  const isGraphEditable = useOfdStore((state) => state.isGraphEditable);
   const { data, isConnectable, type, id } = node;
   const label = data?.formData.formFields[0]?.value;
   const { deleteElements } = useReactFlow();
@@ -34,14 +36,19 @@ export default memo((node) => {
   const connectedEdgesFromNode = useOfdStore((state) => state.connectedEdgesFromNode);
 
 
-  const deleteNode = () => {
-    if (node.data.label !== 'Task') {
-      // Delete the node if it is not of type "Task" which should not be deletable
-      deleteElements({ nodes: [{ id }] });
+  useEffect(() => {
+    if (deletePressed && node.id === selectedNode?.id) {
+      deleteNode();
     }
-    setSetupMode(false)
+  }, [deletePressed]);
+
+  const deleteNode = () => {
+    if (node.data.label !== 'Task' && isGraphEditable) {
+      deleteElements({ nodes: [{ id }] });
+      setSelectedNode(null);
+      setSetupMode(false)
+    }
     setIsPopoverOpen(false)
-    setSelectedNode(null);
   };
 
   const disconnectNode = () => {

--- a/src/pages/ofd/Ofd.tsx
+++ b/src/pages/ofd/Ofd.tsx
@@ -21,7 +21,6 @@ import ReactFlow, {
   Node,
   ReactFlowProvider,
   useEdgesState,
-  useKeyPress,
   useNodesState,
 } from "reactflow";
 import "reactflow/dist/style.css";
@@ -93,7 +92,6 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
     type: "",
   });
   const router = useRouter();
-  const deletePressed = useKeyPress(["Delete"]);
   const [dropInfo, setDropInfo] = useState(null);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [droppedClassName, setDroppedClassName] = useState<null | string>(null);
@@ -103,6 +101,8 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
   const addConnectedEdges = useOfdStore((state) => state.addConnectedEdges);
   const clearConnectedEdges = useOfdStore((state) => state.clearConnectedEdges);
   const doubleClickToEnterSetupMode = userPreferencesStore((state) => state.doubleClickToEnterSetupMode);
+  const isGraphEditable = useOfdStore((state) => state.isGraphEditable);
+  const setIsGraphEditable = useOfdStore((state) => state.setIsGraphEditable);
 
   const [edgeSelections, setEdgeSelections] = useState<string[]>([]);
   const [connectionParams, setConnectionParams] = useState<
@@ -156,11 +156,9 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
     setIsPopoverOpen(false);
   };
 
-  const isNodeDeletable = () => {
-    if (!isEditable) return false;
-    if (selectedNode?.data?.label === "Task") return false;
-    return true;
-  };
+  useEffect(() => {
+    setIsGraphEditable(isEditable);
+  }, [isEditable]);
 
   const onEdgeSelect = (path: string) => {
     setEdges((eds) => {
@@ -185,11 +183,6 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
     }
     return [];
   }, [selectedNode, setupMode]);
-
-  useEffect(() => {
-    exitSetupMode();
-    setSelectedNode(null);
-  }, [deletePressed]);
 
   const saveData = async (data: GraphBody) => {
     const response = await axios.post(`${apiBaseUrl}/api/persist`, data);
@@ -536,7 +529,6 @@ const ForceGraphComponent: React.FC<ForceGraphProps> = ({
                   onPaneClick={handlePaneClick}
                   nodes={nodes}
                   edges={edges}
-                  deleteKeyCode={isNodeDeletable() ? "Delete" : null}
                   onNodesChange={onNodesChange}
                   onEdgesChange={onEdgesChange}
                   connectionLineComponent={ConnectionLine}

--- a/src/store/ofdStore.ts
+++ b/src/store/ofdStore.ts
@@ -13,11 +13,16 @@ interface Node {
 interface OfdStore {
   setupMode: boolean;
   setSetupMode: (value: boolean) => void;
+
   connectedEdgesFromNode: Edge[];
   addConnectedEdges: (edges: Edge | Edge[]) => void;
   clearConnectedEdges: () => void;
+
   selectedNode: Node | null;
   setSelectedNode: (node: Node | null) => void;
+
+  isGraphEditable: boolean;
+  setIsGraphEditable: (value: boolean) => void;
 }
 
 const useOfdStore = create<OfdStore>((set) => ({
@@ -33,8 +38,12 @@ const useOfdStore = create<OfdStore>((set) => ({
       ],
     })),
   clearConnectedEdges: () => set({ connectedEdgesFromNode: [] }),
+
   selectedNode: null,
-  setSelectedNode: (node) => set({ selectedNode: node })
+  setSelectedNode: (node) => set({ selectedNode: node }),
+
+  isGraphEditable: false,
+  setIsGraphEditable: (value) => set({ isGraphEditable: value }),
 }));
 
 export default useOfdStore;


### PR DESCRIPTION
Moved the logic for deleting a node to the CircularNode component instead of having it in the ofd-file.

Created store-variable for "isGraphEditable" that is based on the server-check. 